### PR TITLE
converted float to int

### DIFF
--- a/5_Imaging/5_1_spatial_frequencies.ipynb
+++ b/5_Imaging/5_1_spatial_frequencies.ipynb
@@ -967,13 +967,13 @@
     "    plt.imshow(newImg)\n",
     "    plt.set_cmap('gray')\n",
     "\n",
-    "reconstructImage(fftDuck, 1e1)\n",
+    "reconstructImage(fftDuck, int(1e1))\n",
     "\n",
-    "reconstructImage(fftDuck, 1e3)\n",
+    "reconstructImage(fftDuck, int(1e3))\n",
     "\n",
-    "reconstructImage(fftDuck, 1e5)\n",
+    "reconstructImage(fftDuck, int(1e5))\n",
     "\n",
-    "reconstructImage(fftDuck, 1e6)"
+    "reconstructImage(fftDuck, int(1e6))"
    ]
   },
   {


### PR DESCRIPTION
Otherwise, Python 2 throws a TypeError: 'float' object cannot be interpreted as an index.